### PR TITLE
Update pom.xml to fix CVE

### DIFF
--- a/source/cdk-stack/common-functions/jdbc-query-runner/pom.xml
+++ b/source/cdk-stack/common-functions/jdbc-query-runner/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>com.amazon.redshift</groupId>
             <artifactId>redshift-jdbc42</artifactId>
-            <version>2.1.0.9</version>
+            <version>2.1.0.28</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated pom.xml redshift jdbc version to 2.1.0.28

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
